### PR TITLE
dbutil/queryhelper: return zero-value if no rows found

### DIFF
--- a/dbutil/queryhelper.go
+++ b/dbutil/queryhelper.go
@@ -117,7 +117,7 @@ func (qh *QueryHelper[T]) scanNew(row Scannable) (T, error) {
 func (qh *QueryHelper[T]) QueryOne(ctx context.Context, query string, args ...any) (val T, err error) {
 	val, err = qh.scanNew(qh.db.QueryRow(ctx, query, args...))
 	if errors.Is(err, sql.ErrNoRows) {
-		err = nil
+		return *new(T), nil
 	}
 	return val, err
 }


### PR DESCRIPTION
Without this commit, the `QueryOne` function would return whatever the `(DataStruct[T]).Scan` function returns as the value in the `sql.ErrNoRows` error case. In some cases, the value returned  might be an initialized value. For example, if the following pattern is followed:

	func (s *MyStruct) Scan(row dbutil.Scannable) (*MyStruct, error) {
		err := row.Scan(&s.A, &s.B, &s.C)
		return s, err
	}

Note that even in the error case, the "s" variable will be initialized.

The alternative would be to force the `(DataStruct[T]).Scan` function to return nil if there is an error, but that forces unnecessary verbosity onto the implementer of the interface since they would have to do something like:

	func (s *MyStruct) Scan(row dbutil.Scannable) (*MyStruct, error) {
		err := row.Scan(&s.A, &s.B, &s.C)
		if err != nil {
			return nil, err
		}
		return s, nil
	}

Signed-off-by: Sumner Evans <sumner.evans@automattic.com>
