### PR TITLE
gnuzip: add utilities from beeper/imessage

### DIFF
--- a/gnuzip/gunzip.go
+++ b/gnuzip/gunzip.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2024 Sumner Evans
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package gnuzip
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+)
+
+func MaybeGUnzip(body []byte) ([]byte, error) {
+	reader, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		if errors.Is(err, gzip.ErrHeader) {
+			return body, nil
+		} else {
+			return nil, err
+		}
+	}
+	defer reader.Close()
+	return io.ReadAll(reader)
+}

--- a/gnuzip/gzip.go
+++ b/gnuzip/gzip.go
@@ -1,0 +1,21 @@
+// Copyright (C) 2024 Sumner Evans
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package gnuzip
+
+import (
+	"bytes"
+	"compress/gzip"
+)
+
+func GZip(body []byte) ([]byte, error) {
+	var compressedBuffer bytes.Buffer
+	writer := gzip.NewWriter(&compressedBuffer)
+	if _, err := writer.Write(body); err != nil {
+		return nil, err
+	}
+	return compressedBuffer.Bytes(), writer.Close()
+}


### PR DESCRIPTION
Corresponding code in imessage: https://github.com/beeper/imessage/tree/main/imessage/direct/util/gnuzip

Signed-off-by: Sumner Evans <sumner.evans@automattic.com>
