### PR TITLE
Remove auto-vacuum opts from RO pool DSN

### DIFF
--- a/dbutil/database.go
+++ b/dbutil/database.go
@@ -271,6 +271,8 @@ func NewFromConfig(owner string, cfg Config, logger DatabaseLogger) (*Database, 
 				}
 
 				qs.Del("_txlock")
+				qs.Del("_auto_vacuum")
+				qs.Del("_vacuum")
 			}
 			qs.Set("_query_only", "true")
 


### PR DESCRIPTION
Setting them will require a write lock during connection setup which fights again the idea of a read-only pool.