### PR TITLE
dbutil: rewrite query placeholders without regexp

### DIFF
--- a/dbutil/database.go
+++ b/dbutil/database.go
@@ -134,14 +134,6 @@ func isASCIIDigit(c byte) bool {
 // runs on every query and the regexp engine cost adds up.
 func replacePositionalParams(query string) string {
 	dollar := strings.IndexByte(query, '$')
-	for dollar != -1 && (dollar == len(query)-1 || !isASCIIDigit(query[dollar+1])) {
-		next := strings.IndexByte(query[dollar+1:], '$')
-		if next == -1 {
-			dollar = -1
-		} else {
-			dollar += 1 + next
-		}
-	}
 	if dollar == -1 {
 		return query
 	}

--- a/dbutil/database.go
+++ b/dbutil/database.go
@@ -11,7 +11,6 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
-	"regexp"
 	"strings"
 	"time"
 
@@ -126,12 +125,43 @@ type Database struct {
 
 var ForceDeadlockDetection bool
 
-var positionalParamPattern = regexp.MustCompile(`\$(\d+)`)
+func isASCIIDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+// replacePositionalParams rewrites $1-style placeholders into SQLite's ?1
+// form, equivalent to regexp `\$(\d+)` -> "?$1". Hand-rolled because it
+// runs on every query and the regexp engine cost adds up.
+func replacePositionalParams(query string) string {
+	dollar := strings.IndexByte(query, '$')
+	for dollar != -1 && (dollar == len(query)-1 || !isASCIIDigit(query[dollar+1])) {
+		next := strings.IndexByte(query[dollar+1:], '$')
+		if next == -1 {
+			dollar = -1
+		} else {
+			dollar += 1 + next
+		}
+	}
+	if dollar == -1 {
+		return query
+	}
+	var out strings.Builder
+	out.Grow(len(query))
+	out.WriteString(query[:dollar])
+	for i := dollar; i < len(query); i++ {
+		if query[i] == '$' && i+1 < len(query) && isASCIIDigit(query[i+1]) {
+			out.WriteByte('?')
+		} else {
+			out.WriteByte(query[i])
+		}
+	}
+	return out.String()
+}
 
 func (db *Database) mutateQuery(query string) string {
 	switch db.Dialect {
 	case SQLite:
-		return positionalParamPattern.ReplaceAllString(query, "?$1")
+		return replacePositionalParams(query)
 	default:
 		return query
 	}

--- a/dbutil/database_test.go
+++ b/dbutil/database_test.go
@@ -1,0 +1,90 @@
+package dbutil
+
+import (
+	"regexp"
+	"testing"
+)
+
+var positionalParamRegex = regexp.MustCompile(`\$(\d+)`)
+
+func regexReplacePositionalParams(query string) string {
+	return positionalParamRegex.ReplaceAllString(query, "?$1")
+}
+
+func TestReplacePositionalParams(t *testing.T) {
+	cases := []string{
+		"",
+		"$",
+		"$1",
+		"$12",
+		"a$",
+		"$a",
+		"$$1",
+		"$1$2$3",
+		"$ 1",
+		"no placeholders at all",
+		"trailing dollar $",
+		"SELECT session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id=$2",
+		"INSERT INTO whatsmeow_sessions (our_jid, their_id, session) VALUES ($1, $2, $3) ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session",
+		"SELECT their_id, session FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id IN ($2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)",
+		"WHERE a=$2 AND b=$1",
+		"cost: US$50 AND id=$7",
+		"weird $0 but valid",
+		"unicode é$1ç $2ü",
+		"$999999999999",
+	}
+	for _, query := range cases {
+		expected := regexReplacePositionalParams(query)
+		actual := replacePositionalParams(query)
+		if actual != expected {
+			t.Errorf("mismatch for %q:\nregexp:  %q\nscanner: %q", query, expected, actual)
+		}
+	}
+}
+
+// Generated coverage: every 3-character combination of a small relevant
+// alphabet must behave identically to the regexp it replaces.
+func TestReplacePositionalParamsExhaustive(t *testing.T) {
+	alphabet := []byte{'$', '1', '0', 'a', ' ', '?'}
+	var build func(prefix string, depth int)
+	build = func(prefix string, depth int) {
+		expected := regexReplacePositionalParams(prefix)
+		actual := replacePositionalParams(prefix)
+		if actual != expected {
+			t.Errorf("mismatch for %q: regexp=%q scanner=%q", prefix, expected, actual)
+		}
+		if depth == 0 {
+			return
+		}
+		for _, c := range alphabet {
+			build(prefix+string(c), depth-1)
+		}
+	}
+	build("", 4)
+}
+
+func TestReplacePositionalParamsNoAllocWithoutPlaceholders(t *testing.T) {
+	query := "SELECT * FROM table WHERE nothing"
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = replacePositionalParams(query)
+	})
+	if allocs != 0 {
+		t.Errorf("expected 0 allocations for query without placeholders, got %.1f", allocs)
+	}
+}
+
+func BenchmarkReplacePositionalParams(b *testing.B) {
+	query := "INSERT INTO whatsmeow_sessions (our_jid, their_id, session) VALUES ($1, $2, $3) ON CONFLICT (our_jid, their_id) DO UPDATE SET session=excluded.session"
+	b.Run("scanner", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = replacePositionalParams(query)
+		}
+	})
+	b.Run("regexp", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = regexReplacePositionalParams(query)
+		}
+	})
+}


### PR DESCRIPTION
With the SQLite dialect, `mutateQuery` runs `positionalParamPattern.ReplaceAllString` on every query that goes through `LoggingExecable`, so the regexp engine cost is paid on every single Exec/Query/QueryRow. This replaces it with a hand-rolled scan doing the same `$N` to `?N` rewrite: queries without placeholders return the input string with zero allocations, and queries with placeholders cost one allocation for the rewritten string.

The new test checks the function against the old regexp on every combination of up to 4 characters from a relevant alphabet plus some realistic queries, so the behavior is provably identical. Benchmark on a typical INSERT:

```
BenchmarkReplacePositionalParams/scanner-12    166.4 ns/op    160 B/op    1 allocs/op
BenchmarkReplacePositionalParams/regexp-12     578.9 ns/op    514 B/op    7 allocs/op
```

I also considered caching rewritten queries, but dynamically built queries (IN clauses, mass inserts) would make the cache unbounded, and the scanner already gets it down to the single unavoidable allocation.


Before/after heap profiles from a whatsmeow ping/pong benchmark that uses this library with SQLite, viewable in speedscope: [before](https://www.speedscope.app/#profileURL=https%3A%2F%2Fgist.githubusercontent.com%2Fjlucaso1%2F38446f6dc8971fc2820e5c25bf74cdfc%2Fraw%2Fmain-heap.folded.txt&title=before%20%28main%29%20heap), [after](https://www.speedscope.app/#profileURL=https%3A%2F%2Fgist.githubusercontent.com%2Fjlucaso1%2F38446f6dc8971fc2820e5c25bf74cdfc%2Fraw%2Fgoutil-fix-heap.folded.txt&title=after%20%28dbutil%20fix%29%20heap). `mutateQuery` drops from 111MB to 22MB of allocations over the run, with the regexp machinery replaced by the single allocation of the rewritten string.
